### PR TITLE
Added unit tests for cursor moving through editor

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -855,6 +855,7 @@ fn process_prompt_keypress(mut buffer: String, key: &Key) -> PromptState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     #[test]
     fn format_size_output() {
@@ -923,5 +924,170 @@ mod tests {
         editor.move_cursor(&AKey::Left, false);
         editor.delete_char();
         assert_eq!(editor.rows[0].chars, "Helo world".as_bytes());
+    }
+
+    #[test]
+    fn editor_move_cursor_left() {
+        let mut editor = Editor::default();
+        for b in "Hello world!\nHappy New Year!".as_bytes() {
+            if *b == b'\n' {
+                editor.insert_new_line();
+            } else {
+                editor.insert_byte(*b);
+            }
+        }
+
+        // check current position
+        assert_eq!(editor.cursor.x, 15);
+        assert_eq!(editor.cursor.y, 1);
+
+        editor.move_cursor(&AKey::Left, true);
+        assert_eq!(editor.cursor.x, 10);
+        assert_eq!(editor.cursor.y, 1);
+
+        editor.move_cursor(&AKey::Left, false);
+        assert_eq!(editor.cursor.x, 9);
+        assert_eq!(editor.cursor.y, 1);
+        
+        editor.move_cursor(&AKey::Left, true);
+        assert_eq!(editor.cursor.x, 6);
+        assert_eq!(editor.cursor.y, 1);
+        
+        editor.move_cursor(&AKey::Left, true);
+        assert_eq!(editor.cursor.x, 0);
+        assert_eq!(editor.cursor.y, 1);
+
+        editor.move_cursor(&AKey::Left, false);
+        assert_eq!(editor.cursor.x, 12);
+        assert_eq!(editor.cursor.y, 0);
+
+        editor.move_cursor(&AKey::Left, true);
+        assert_eq!(editor.cursor.x, 6);
+        assert_eq!(editor.cursor.y, 0);
+
+        editor.move_cursor(&AKey::Left, true);
+        assert_eq!(editor.cursor.x, 0);
+        assert_eq!(editor.cursor.y, 0);
+
+        editor.move_cursor(&AKey::Left, false);
+        assert_eq!(editor.cursor.x, 0);
+        assert_eq!(editor.cursor.y, 0);
+    }
+
+    #[test]
+    fn editor_move_cursor_up() {
+        let mut editor = Editor::default();
+        for b in b"abcdefgh\nij\nklmnopqrstuvwxyz" {
+            if *b == b'\n' {
+                editor.insert_new_line();
+            } else {
+                editor.insert_byte(*b);
+            }
+        }
+
+        // check current position
+        assert_eq!(editor.cursor.x, 16);
+        assert_eq!(editor.cursor.y, 2);
+
+        editor.move_cursor(&AKey::Up, false);
+        assert_eq!(editor.cursor.x, 2);     
+        assert_eq!(editor.cursor.y, 1);     
+
+        editor.move_cursor(&AKey::Up, true);
+        assert_eq!(editor.cursor.x, 2);    
+        assert_eq!(editor.cursor.y, 0);     
+        
+        editor.move_cursor(&AKey::Up, false);
+        assert_eq!(editor.cursor.x, 2); 
+        assert_eq!(editor.cursor.y, 0);     
+    }
+
+    #[test]
+    fn editor_move_cursor_right() {
+        let mut editor = Editor::default();
+        for b in "Hello world\nHappy New Year".as_bytes() {
+            if *b == b'\n' {
+                editor.insert_new_line();
+            } else {
+                editor.insert_byte(*b);
+            }
+        }
+
+        // check current position
+        assert_eq!(editor.cursor.x, 14);
+        assert_eq!(editor.cursor.y, 1);
+
+        editor.move_cursor(&AKey::Right, false);
+        assert_eq!(editor.cursor.x, 0);
+        assert_eq!(editor.cursor.y, 2);
+
+        editor.move_cursor(&AKey::Right, false);
+        assert_eq!(editor.cursor.x, 0);
+        assert_eq!(editor.cursor.y, 2);
+        
+        editor.move_cursor(&AKey::Up, true);
+        editor.move_cursor(&AKey::Up, true);
+        assert_eq!(editor.cursor.x, 0);
+        assert_eq!(editor.cursor.y, 0);
+
+        editor.move_cursor(&AKey::Right, true);
+        assert_eq!(editor.cursor.x, 5);
+        assert_eq!(editor.cursor.y, 0);
+
+        editor.move_cursor(&AKey::Right, true);
+        assert_eq!(editor.cursor.x, 11);
+        assert_eq!(editor.cursor.y, 0);
+        
+        // It is going to the next row on the same x, not resetting the x axis
+        editor.move_cursor(&AKey::Right, false);
+        assert_eq!(editor.cursor.x, 0);
+        assert_eq!(editor.cursor.y, 1);
+    }
+
+    #[test]
+    fn editor_move_cursor_down() {
+        let mut editor = Editor::default();
+        for b in b"abcdefgh\nij\nklmnopqrstuvwxyz" {
+            if *b == b'\n' {
+                editor.insert_new_line();
+            } else {
+                editor.insert_byte(*b);
+            }
+        }
+        
+        // check current position
+        assert_eq!(editor.cursor.x, 16);
+        assert_eq!(editor.cursor.y, 2);
+
+        editor.move_cursor(&AKey::Down, false);
+        assert_eq!(editor.cursor.x, 0);
+        assert_eq!(editor.cursor.y, 3);
+
+        editor.move_cursor(&AKey::Up, false);
+        editor.move_cursor(&AKey::Up, false);
+        editor.move_cursor(&AKey::Up, false);
+
+        assert_eq!(editor.cursor.x, 0);
+        assert_eq!(editor.cursor.y, 0);
+
+        editor.move_cursor(&AKey::Right, true);
+        assert_eq!(editor.cursor.x, 8);
+        assert_eq!(editor.cursor.y, 0);
+
+        editor.move_cursor(&AKey::Down, true);
+        assert_eq!(editor.cursor.x, 2);
+        assert_eq!(editor.cursor.y, 1);
+
+        editor.move_cursor(&AKey::Down, true);
+        assert_eq!(editor.cursor.x, 2);
+        assert_eq!(editor.cursor.y, 2);
+
+        editor.move_cursor(&AKey::Down, true);
+        assert_eq!(editor.cursor.x, 0);
+        assert_eq!(editor.cursor.y, 3);
+
+        editor.move_cursor(&AKey::Down, false);
+        assert_eq!(editor.cursor.x, 0);
+        assert_eq!(editor.cursor.y, 3);
     }
 }


### PR DESCRIPTION
This pull request adds some unit tests for cursor moving. 
Issue: [#124](https://github.com/ilai-deutel/kibi/issues/124)